### PR TITLE
Load data from IPFS directly, instead of via IPFS API

### DIFF
--- a/src/lib/Player.svelte
+++ b/src/lib/Player.svelte
@@ -16,7 +16,7 @@
     <audio
       controls
       autoplay
-      src="https://ipfs.io/api/v0/cat?arg={$root}/{$currentTrack.data_folder}/{$currentTrack.stereo_mix.vorbis}">
+      src="https://ipfs.io{$root}/{$currentTrack.data_folder}/{$currentTrack.stereo_mix.vorbis}">
       <track kind="captions" src="data:%5b%e2%99%ab music %e2%99%ab%5d" />
       Your browser does not support the
       <code>audio</code> element.

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -9,12 +9,12 @@
 
       root.set(Path)
 
-      const reqMetadata = await fetch(`https://ipfs.io/api/v0/cat?arg=${Path}/metadata.json`)
+      const reqMetadata = await fetch(`https://ipfs.io${Path}/metadata.json`)
       console.log(reqMetadata)
       const seasons = await reqMetadata.json()
 
       const data = await Promise.all(seasons.map(async season => {
-        const req = await fetch(`https://ipfs.io/api/v0/cat?arg=${Path}/${season.path}/metadata.json`)
+        const req = await fetch(`https://ipfs.io${Path}/${season.path}/metadata.json`)
         return {
           path: season.path,
           ...(await req.json())


### PR DESCRIPTION
Will this change, data is loaded from urls like:

    https://ipfs.io/ipfs/QmHaSh/metadata.json

instead of:

    https://ipfs.io/api/v0/cat?arg=/ipfs/QmHash/metadata.json