### PR TITLE
Fixes and types for cookies.ts

### DIFF
--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -1,18 +1,25 @@
-export const datetimeAfter = (seconds: number) => {
+export const datetimeAfter = (seconds: number): Date => {
 	const time = new Date();
-	time.setSeconds(time.getSeconds() + seconds);
-	return time;
+	return new Date(time.valueOf() + seconds * 1000);
 };
 
-export const getCookies = (cookie) =>
+export const getCookies = (cookie: string): { [k: string]: string } =>
 	Object.fromEntries(
 		cookie ? cookie.split(';').map((c) => c.split('=').map((c2) => c2.trim())) : []
 	);
 
-export const setCookie = (name, value, { path = '/', expires = null, httpOnly = true } = {}) => {
+export const setCookie = (
+	name: string,
+	value: string,
+	{
+		path = '/',
+		expires = null,
+		httpOnly = true
+	}: { path?: string; expires?: Date; httpOnly?: boolean } = {}
+): string => {
 	expires = expires ?? datetimeAfter(60 * 60 * 24);
 
-	const parts = [`${name}=${value}`, `Path=${path}`, `Expires=${expires}`];
+	const parts = [`${name}=${value}`, `Path=${path}`, `Expires=${expires.toUTCString()}`];
 	if (httpOnly) {
 		parts.push(`HttpOnly`);
 	}


### PR DESCRIPTION
Two fixes:

* The `datetimeAfter` function wasn't doing the right thing. It was just
resetting the "seconds", instead of adding the number of seconds to
the date.
* The `Expires` field needs a date fomatted with `toUTCString()`

While I was at it, I also added type annotations to everything